### PR TITLE
Spring 5 Upgrade Compatibility

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security.extensions</groupId>
   <artifactId>spring-security-saml2-core</artifactId>
-  <version>1.0.3.KZO-RELEASE-4</version>
+  <version>1.0.3.KZO-RELEASE-5</version>
   <name>Spring Security SAML v2 library</name>
   <description>Spring Security SAML v2 library</description>
   <url>https://github.com/SpringSource/spring-security-saml</url>
@@ -19,13 +19,6 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <mailingLists>
-    <mailingList>
-      <name>Spring Security SAML Forum</name>
-      <post>http://forum.springsource.org/forumdisplay.php?86-SAML</post>
-      <archive>http://forum.springsource.org/forumdisplay.php?86-SAML</archive>
-    </mailingList>
-  </mailingLists>
   <developers>
     <developer>
       <id>vschafer</id>
@@ -48,15 +41,22 @@
       <name>Wade Dorrell</name>
     </contributor>
   </contributors>
-  <issueManagement>
-    <system>jira</system>
-    <url>http://jira.springsource.org/browse/SES</url>
-  </issueManagement>
+  <mailingLists>
+    <mailingList>
+      <name>Spring Security SAML Forum</name>
+      <post>http://forum.springsource.org/forumdisplay.php?86-SAML</post>
+      <archive>http://forum.springsource.org/forumdisplay.php?86-SAML</archive>
+    </mailingList>
+  </mailingLists>
   <scm>
     <connection>scm:git:git://github.com/SpringSource/spring-security-saml</connection>
     <developerConnection>scm:git:git://github.com/SpringSource/spring-security-saml</developerConnection>
     <url>https://github.com/SpringSource/spring-security-saml</url>
   </scm>
+  <issueManagement>
+    <system>jira</system>
+    <url>http://jira.springsource.org/browse/SES</url>
+  </issueManagement>
   <dependencies>
     <dependency>
       <groupId>org.opensaml</groupId>

--- a/core/src/main/java/org/springframework/security/saml/SAMLBootstrap.java
+++ b/core/src/main/java/org/springframework/security/saml/SAMLBootstrap.java
@@ -20,7 +20,7 @@ import org.opensaml.xml.ConfigurationException;
 import org.opensaml.xml.security.keyinfo.NamedKeyInfoGeneratorManager;
 import org.opensaml.xml.security.x509.X509KeyInfoGeneratorFactory;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.access.BootstrapException;
+import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
@@ -42,7 +42,7 @@ public class SAMLBootstrap implements BeanFactoryPostProcessor {
             PaosBootstrap.bootstrap();
             setMetadataKeyInfoGenerator();
         } catch (ConfigurationException e) {
-            throw new BootstrapException("Error invoking OpenSAML bootstrap", e);
+            throw new FatalBeanException("Error invoking OpenSAML bootstrap", e);
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.0.3.KZO-RELEASE-4
+version=1.0.3.KZO-RELEASE-5
 maxParallelForks=1


### PR DESCRIPTION
BootstrapException no longer exists in Spring 5, switch to FatalBeanException.  
Fix was pulled from the spring-security-saml project

You might need to fiddle with gradlew to get it to run.

Eventually, our entire SAML integration needs to be replaced w/ the one thats being built in spring-security.  
Spring-Security currently lacks SLO, so we'll need to wait for that.